### PR TITLE
Feat/pagination

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
 		"@fortawesome/react-fontawesome": "^0.2.0",
 		"@react-google-maps/api": "^2.18.1",
 		"@reduxjs/toolkit": "^1.9.3",
+		"antd": "^5.3.3",
 		"axios": "^1.3.4",
 		"bootstrap": "^5.2.3",
 		"dotenv": "^16.0.3",

--- a/client/src/components/Cards/Cards.jsx
+++ b/client/src/components/Cards/Cards.jsx
@@ -7,6 +7,9 @@ import styles from './Cards.module.css'
 export function Cards() {
 	const filterState = useSelector(state => state.filter)
 	const { data, isLoading, error } = useGetShoesQuery(filterState)
+	const { page, pageSize } = useSelector(state => state.pagination)
+
+	const slicedData = data.slice((page - 1) * pageSize, page * pageSize)
 
 	if (isLoading)
 		return (
@@ -25,11 +28,11 @@ export function Cards() {
 	return (
 		<div
 			className={
-				data.length ? styles.cardsContainer : styles.cardsContainerNotFound
+				slicedData.length ? styles.cardsContainer : styles.cardsContainerNotFound
 			}
 		>
-			{data.length ? (
-				data.map(shoe => <Card key={shoe.id} shoe={shoe} />)
+			{slicedData.length ? (
+				slicedData.map(shoe => <Card key={shoe.id} shoe={shoe} />)
 			) : (
 				<NotFound />
 			)}

--- a/client/src/components/Cards/Cards.jsx
+++ b/client/src/components/Cards/Cards.jsx
@@ -1,15 +1,24 @@
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { Card, Loader, NotFound } from '../../components'
 import { useGetShoesQuery } from '../../redux/services/filteredShoes'
-
+import {
+	setPage,
+	setTotalEntries
+} from '../../redux/slices/pagination/paginationSlice'
 import styles from './Cards.module.css'
 
 export function Cards() {
+	const dispatch = useDispatch()
 	const filterState = useSelector(state => state.filter)
 	const { data, isLoading, error } = useGetShoesQuery(filterState)
 	const { page, pageSize } = useSelector(state => state.pagination)
 
-	const slicedData = data.slice((page - 1) * pageSize, page * pageSize)
+	let slicedData = []
+	if (data) {
+		if ((page - 1) * pageSize > data.length) dispatch(setPage(1))
+		dispatch(setTotalEntries(data.length))
+		slicedData = data.slice((page - 1) * pageSize, page * pageSize)
+	}
 
 	if (isLoading)
 		return (
@@ -28,7 +37,9 @@ export function Cards() {
 	return (
 		<div
 			className={
-				slicedData.length ? styles.cardsContainer : styles.cardsContainerNotFound
+				slicedData.length
+					? styles.cardsContainer
+					: styles.cardsContainerNotFound
 			}
 		>
 			{slicedData.length ? (

--- a/client/src/pages/Sneakers/Sneakers.jsx
+++ b/client/src/pages/Sneakers/Sneakers.jsx
@@ -9,22 +9,14 @@ import {
 	CurrentFilters
 } from '../../components'
 import { Pagination } from 'antd'
-import { useEffect } from 'react'
-import {
-	setPage,
-	setTotalPages
-} from '../../redux/slices/pagination/paginationSlice'
+import { setPage } from '../../redux/slices/pagination/paginationSlice'
 import { useDispatch, useSelector } from 'react-redux'
-// import { useGetShoesQuery } from '../../redux/services/filteredShoes'
 
 export function Sneakers() {
 	const dispatch = useDispatch()
-	// const filterState = useSelector(state => state.filter)
-	const { page, pageSize, totalPages } = useSelector(state => state.pagination)
-
-	useEffect(() => {
-		dispatch(setTotalPages(21))
-	}, [])
+	const { page, pageSize, totalEntries } = useSelector(
+		state => state.pagination
+	)
 	const onChangeHandler = (page, pageSize) => {
 		dispatch(setPage(page))
 	}
@@ -43,7 +35,7 @@ export function Sneakers() {
 				<Pagination
 					current={page}
 					size={pageSize}
-					total={totalPages}
+					total={totalEntries}
 					onChange={onChangeHandler}
 				/>
 			</div>

--- a/client/src/pages/Sneakers/Sneakers.jsx
+++ b/client/src/pages/Sneakers/Sneakers.jsx
@@ -8,8 +8,26 @@ import {
 	WhatsAppButton,
 	CurrentFilters
 } from '../../components'
+import { Pagination } from 'antd'
+import { useEffect } from 'react'
+import {
+	setPage,
+	setTotalPages
+} from '../../redux/slices/pagination/paginationSlice'
+import { useDispatch, useSelector } from 'react-redux'
+// import { useGetShoesQuery } from '../../redux/services/filteredShoes'
 
 export function Sneakers() {
+	const dispatch = useDispatch()
+	// const filterState = useSelector(state => state.filter)
+	const { page, pageSize, totalPages } = useSelector(state => state.pagination)
+
+	useEffect(() => {
+		dispatch(setTotalPages(21))
+	}, [])
+	const onChangeHandler = (page, pageSize) => {
+		dispatch(setPage(page))
+	}
 	return (
 		<div>
 			<Navbar />
@@ -20,6 +38,14 @@ export function Sneakers() {
 				</div>
 				<CurrentFilters />
 				<Cards />
+			</div>
+			<div className={styles.paginationContainer}>
+				<Pagination
+					current={page}
+					size={pageSize}
+					total={totalPages}
+					onChange={onChangeHandler}
+				/>
 			</div>
 			<WhatsAppButton />
 			<Footer />

--- a/client/src/pages/Sneakers/Sneakers.module.css
+++ b/client/src/pages/Sneakers/Sneakers.module.css
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	padding-bottom: 150px;
+	padding-bottom: 2rem;
 }
 
 .filters {
@@ -11,6 +11,12 @@
 
 	display: flex;
 	justify-content: space-between;
+}
+
+.paginationContainer {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 3rem;
 }
 
 @media (min-width: 768px) {

--- a/client/src/redux/slices/index.js
+++ b/client/src/redux/slices/index.js
@@ -1,3 +1,4 @@
 export * from './auth'
 export * from './filters/filterSlice'
 export * from './cart'
+export * from './pagination/paginationSlice'

--- a/client/src/redux/slices/pagination/paginationSlice.js
+++ b/client/src/redux/slices/pagination/paginationSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export const paginationSlice = createSlice({
+	name: 'pagination',
+	initialState: {
+		page: 1,
+		pageSize: 9,
+		totalPages: 1
+	},
+	reducers: {
+		setPage: (state, action) => {
+			state.page = action.payload
+		},
+		setTotalPages: (state, action) => {
+			state.totalPages = action.payload
+		}
+	}
+})
+
+export const { setPage, setTotalPages } = paginationSlice.actions

--- a/client/src/redux/slices/pagination/paginationSlice.js
+++ b/client/src/redux/slices/pagination/paginationSlice.js
@@ -5,16 +5,16 @@ export const paginationSlice = createSlice({
 	initialState: {
 		page: 1,
 		pageSize: 9,
-		totalPages: 1
+		totalEntries: 1
 	},
 	reducers: {
 		setPage: (state, action) => {
 			state.page = action.payload
 		},
-		setTotalPages: (state, action) => {
-			state.totalPages = action.payload
+		setTotalEntries: (state, action) => {
+			state.totalEntries = action.payload
 		}
 	}
 })
 
-export const { setPage, setTotalPages } = paginationSlice.actions
+export const { setPage, setTotalEntries } = paginationSlice.actions

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -1,5 +1,5 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
-import { authSlice, cartSlice, filterSlice } from './slices'
+import { authSlice, cartSlice, filterSlice, paginationSlice } from './slices'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
 import { shoesApi } from './services/services'
 import { filteredShoesApi } from './services/filteredShoes'
@@ -18,6 +18,7 @@ const reducer = combineReducers({
 	auth: authSlice.reducer,
 	filter: filterSlice.reducer,
 	cart: cartSlice.reducer,
+	pagination: paginationSlice.reducer
 })
 
 const persistedReducer = persistReducer(persistConfig, reducer)


### PR DESCRIPTION
- añadir paginado usando interfaz de https://ant.design/components/pagination con una librería nueva ("antd")
- añadir paginationSlice que guarda en store tres variables: page, pageSize, totalEntries. Que significan página actual, tamaño de paginado y cantidad de elementos respectivamente
- el reducer de paginationSlice tiene 2 acciones: setPage para cambiar la página actual, y setTotalEntries para establecer cuántas zapatillas hay que paginar

La funcionalidad está distribuida en los siguientes archivos:
1. (client\src\pages\Sneakers\Sneakers.jsx): se trae page, pageSize y totalEntries de la store para renderizar un componente Pagination que viene de la librería "antd", éste acepta varios params en los cuales dentro del onChange es donde se hace dispatch de la page actual.
2.  (client\src\components\Cards\Cards.jsx): en vez de utilizar data directamente del query, ahora se crea una constante slicedData que contiene solo los elementos a mostrar de acorde al paginado. Este componente se encarga de setear el totalEntries con un dispatch ya que es el único componente que tiene acceso a data.length, y si la página actual queda fuera de los límites, la setea a 1 para evitar error